### PR TITLE
Add Colorbar component

### DIFF
--- a/src/colorbar/gradient.mjs
+++ b/src/colorbar/gradient.mjs
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Box } from 'theme-ui'
+
+const DIMENSIONS = {
+  width: ['9px', '17px', '17px', '17px'],
+  height: ['80px', '110px', '110px', '130px'],
+}
+
+const Gradient = ({ colormap, horizontal }) => {
+  const values = colormap.map((d, i) => `rgb(${d}) ${(i / 255) * 100}%`)
+
+  const css = `linear-gradient(to ${
+    horizontal ? 'right' : 'top'
+  }, ${values.join(',')})`
+
+  return (
+    <Box
+      sx={{
+        ...(horizontal
+          ? { width: DIMENSIONS.height, height: DIMENSIONS.width }
+          : { width: DIMENSIONS.width, minHeight: DIMENSIONS.height }),
+        border: ({ colors }) => `solid 1px ${colors.hinted}`,
+        background: css,
+      }}
+    />
+  )
+}
+
+export default Gradient

--- a/src/colorbar/index.mjs
+++ b/src/colorbar/index.mjs
@@ -1,0 +1,94 @@
+import React from 'react'
+import { Box, Flex } from 'theme-ui'
+import useColormap from './use-colormap'
+
+import Gradient from './gradient.mjs'
+import Label from './label.mjs'
+
+const ColorbarInner = ({
+  sx,
+  label,
+  colormap,
+  clim,
+  units,
+  format,
+  horizontal,
+}) => {
+  const climMin = (
+    <Box
+      sx={{
+        fontFamily: 'mono',
+        fontSize: ['9px', 0, 0, 1],
+        letterSpacing: 'smallcaps',
+        textTransform: 'uppercase',
+        ml: horizontal ? '10px' : 0,
+        mb: horizontal ? 0 : '-5px',
+      }}
+    >
+      {format(clim[0])}
+    </Box>
+  )
+  const climMax = (
+    <Box
+      sx={{
+        fontFamily: 'mono',
+        fontSize: ['9px', 0, 0, 1],
+        letterSpacing: 'smallcaps',
+        textTransform: 'uppercase',
+        mt: horizontal ? 0 : '-5px',
+      }}
+    >
+      {format(clim[1])}
+    </Box>
+  )
+
+  return (
+    <Flex
+      sx={{
+        ...sx,
+        flexDirection: 'row',
+        justifyContent: 'flex-start',
+        gap: [2],
+      }}
+    >
+      <Label label={label} units={units} horizontal={horizontal} />
+
+      {horizontal && climMin}
+      <Gradient colormap={colormap} horizontal={horizontal} />
+      {horizontal && climMax}
+
+      {!horizontal && (
+        <Flex
+          sx={{
+            flexDirection: 'column-reverse',
+            justifyContent: 'space-between',
+          }}
+        >
+          {climMin}
+          {climMax}
+        </Flex>
+      )}
+    </Flex>
+  )
+}
+
+const DerivedColorbar = ({ colormap, ...props }) => {
+  const derivedColormap = useColormap(colormap)
+
+  return <ColorbarInner {...props} colormap={derivedColormap} />
+}
+
+const Colorbar = ({ colormap, ...props }) => {
+  if (Array.isArray(colormap)) {
+    return <ColorbarInner colormap={colormap} {...props} />
+  } else {
+    return <DerivedColorbar colormap={colormap} {...props} />
+  }
+}
+
+Colorbar.defaultProps = {
+  format: (d) => d,
+  horizontal: false,
+}
+
+export default Colorbar

--- a/src/colorbar/label.mjs
+++ b/src/colorbar/label.mjs
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Box } from 'theme-ui'
+
+const Label = ({ label, units, horizontal }) => (
+  <Box sx={!horizontal && { alignSelf: 'flex-end' }}>
+    <Box
+      sx={{
+        fontFamily: 'mono',
+        fontSize: ['9px', 0, 0, 1],
+        letterSpacing: 'smallcaps',
+        textTransform: 'uppercase',
+        ...(horizontal
+          ? {}
+          : {
+              writingMode: 'vertical-rl',
+              transform: 'rotate(180deg)',
+              whiteSpace: 'nowrap',
+              display: 'inline-block',
+              overflow: 'visible',
+            }),
+      }}
+    >
+      {label}{' '}
+      <Box
+        as='span'
+        sx={{
+          textTransform: 'none',
+          color: 'secondary',
+          display: 'inline-block',
+        }}
+      >
+        {units}
+      </Box>
+    </Box>
+  </Box>
+)
+export default Label

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,2 +1,3 @@
 export { default as useColormap } from './use-colormap'
 export { default as colormaps } from './colormaps'
+export { default as Colorbar } from './colorbar'


### PR DESCRIPTION
Resolves https://github.com/carbonplan/colormaps/issues/3

This PR adds a new `Colorbar` component, which renders a labeled colorbar legend either vertically (default) or horizontally. Note that as currently implemented, long labels will extend the length of the colorbar gradient beyond the default length when rendered vertically.

```jsx
<Colorbar
  label={label}
  format={format('~s')}
  colormap={colormap}
  clim={clim}
  units='MtCO2'
/>
```
<img width="129" alt="Screen Shot 2021-10-01 at 2 32 41 PM" src="https://user-images.githubusercontent.com/12436887/135688866-54898cd5-ad5e-4b34-a9a6-6156e8738aa0.png"> <img width="138" alt="Screen Shot 2021-10-01 at 2 32 50 PM" src="https://user-images.githubusercontent.com/12436887/135688867-da86b8aa-2ac3-419c-9117-1fb50fe9a132.png"> <img width="137" alt="Screen Shot 2021-10-01 at 2 33 04 PM" src="https://user-images.githubusercontent.com/12436887/135688868-914c27a1-80d5-4f28-996d-158124ea13d6.png">

```jsx
<Colorbar
  label='biomass'
  horizontal
  format={format('~s')}
  colormap={colormap}
  clim={clim}
  units='MtCO2'
/>
```
<img width="343" alt="Screen Shot 2021-10-01 at 2 39 14 PM" src="https://user-images.githubusercontent.com/12436887/135689080-65725ecf-ea62-4068-b392-b502129693a2.png">
