### PR TITLE
Restore color mode fallback in useThemedColormap

### DIFF
--- a/src/use-themed-colormap.mjs
+++ b/src/use-themed-colormap.mjs
@@ -3,7 +3,16 @@ import useColormap from './use-colormap'
 
 const useThemedColormap = (name, options) => {
   const [mode] = useColorMode()
-  return useColormap(name, { ...options, mode: mode })
+
+  let colorMode = mode
+
+  if (!['light', 'dark'].includes(mode)) {
+    console.warn(
+      `Unexpected \`theme-ui-color-mode\`, ${mode}. Using \`dark\` as fallback.`
+    )
+    colorMode = 'dark'
+  }
+  return useColormap(name, { ...options, mode: colorMode })
 }
 
 export default useThemedColormap


### PR DESCRIPTION
- Adds fallback to `dark` color mode in `useThemedColormap` that previously existed in `useColormap` before the refactor in https://github.com/carbonplan/colormaps/pull/7
  - Handles cases where an unexpected colormap is present (we may want to look further into how this happens, but because of connection to local storage, etc. it seems likely that we will encounter unexpected values on at least initial renders)